### PR TITLE
添加默认的快捷键来触发browser action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,15 @@
     "16": "appicon_16.png",
     "48": "appicon_48.png",
     "128": "appicon_128.png"
-  }
+  },
+  "commands": {
+     "_execute_browser_action": {
+       "suggested_key": {
+          "windows": "Ctrl+Shift+P",
+          "mac": "Command+Shift+P",
+          "chromeos": "Ctrl+Shift+P",
+          "linux": "Ctrl+Shift+P"
+       }
+     }
+   }
 }


### PR DESCRIPTION
目前仅在beta和dev channel的chrome里中支持
mac下为Command+Shift+P
其他操作系统为Ctrl+Shift+P
