### PR TITLE
Enclose selected text in <blockquote> in description field

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -50,7 +50,9 @@ var copySel2desc = function () {
             chrome.tabs.sendRequest(
                 tab.id, {method: "getSelection"},
                 function (response) {
-                    $('#desc').val(response.data);
+                    if (response.data.length !== 0) {
+                      $('#desc').val('<blockquote>' + response.data + '</blockquote>');
+                    }
                 });
         });
 };


### PR DESCRIPTION
Pinboard allows `<blockquote>` tags for quotes in link descriptions; I typically use these to indicate what parts of the description are my notes vs. what is content from the original page.

This PR automatically encloses the link description in `<blockquote>` tags when it's populated from the window's current selection.
