### PR TITLE
Make <blockquote> on selected text optional

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -3,6 +3,7 @@ var _userInfo = null, _tags = [], keyprefix = 'pbuinfo',
 namekey = keyprefix + 'n', pwdkey = keyprefix + 'p', checkedkey = keyprefix + 'c',
 nopingKey = keyprefix + 'np', // config in the settings for not checking page pin state
 allprivateKey = keyprefix + 'allprivate', // config in the settings for always check the private checkbox
+useblockquoteKey = keyprefix + 'useblockquote', // config in the settings for wrapping text with <blockquote>
 mainPath = 'https://api.pinboard.in/v1/',
 yesIcon = '/img/icon_colored_19.png', noIcon = '/img/icon_grey_19.png', savingIcon = '/img/icon_grey_saving_19.png';
 var REQ_TIME_OUT = 125 * 1000, maxDescLen = 500;

--- a/js/options.js
+++ b/js/options.js
@@ -10,4 +10,9 @@ $(function() {
                      var value = $(this).is(':checked');
                      localStorage[allprivateKey] = value;
                  });
+      $('#use-blockquote').attr('checked', localStorage[useblockquoteKey] === 'true')
+          .click(function () {
+                     var value = $(this).is(':checked');
+                     localStorage[useblockquoteKey] = value;
+                 });
   });

--- a/js/popup.js
+++ b/js/popup.js
@@ -57,8 +57,10 @@ app.controller(
                                        if (desc.length > maxDescLen) {
                                            desc = desc.slice(0, maxDescLen) + '...'
                                        }
-                                       $scope.pageInfo.desc = '<blockquote>' + desc +
-                                           '</blockquote>';
+                                       if (localStorage[useblockquoteKey] === 'true') {
+                                           desc = '<blockquote>' + desc + '</blockquote>';
+                                       }
+                                       $scope.pageInfo.desc = desc;
                                        $scope.isQuoteHintShown = true;
                                        $scope.$apply();
                                    }

--- a/templates/options.html
+++ b/templates/options.html
@@ -25,6 +25,10 @@
     <span class="checkbox"><input type="checkbox" id="all-private" /></span>
       <label for="all-private">Private checkbox checked by default</label>
     </p>
+    <p>
+      <span class="checkbox"><input type="checkbox" id="use-blockquote" /></span>
+      <label for="use-blockquote">Wrap selected text on a page with <code>&lt;blockquote&gt;</code> in the Notes field</label>
+    </p>
   </section>
 </body>
 


### PR DESCRIPTION
I don't want `<blockquote>` around my Notes text, so I changed it to be an option. This works fine for me, but it has a few issues that could be improved.
1. The new text on the options page shows up as shifted to the right for some reason, and I'm not sure why. It seems like the third `<p>` in the `<section>` is always this way. Maybe you know why?
   ![pinboard-options](https://cloud.githubusercontent.com/assets/54900/3027963/cdb6d2d4-e027-11e3-9324-9d4ae4ac62fb.jpg)
2. This changes the default for using `<blockquote>`s to `false`, which would probably surprise users. I think it's logically better to present the option where `checked` means “use `<blockquote>`s” instead of “don't use.” However, It would probably be a good idea to set the default to `true`. I wasn't sure of the appropriate way to do that.
