### PR TITLE
Feature Add: utilizing local meta keywords tags to suggest better and more relevant tags

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -29,7 +29,7 @@
   "content_scripts": [{
       "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start",
-      "js": ["scripts/description.js"],
+      "js": ["scripts/description.js", "scripts/keywords_suggestions.js"],
       "all_frames": true
     }],
   "icons": {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -255,7 +255,6 @@ var getSuggest = function (url, keywordTags) {
 
 	  if (keywordTags !== undefined && keywordTags.length !== 0) {
         suggests = suggests.concat(keywordTags);
-        console.log("Post Suggested Tags: " + suggests);
 		suggests = suggests.sort().filter(function(item, pos, ary) {return !pos || item != ary[pos -  1];});
       }
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -237,7 +237,7 @@ var deletePost = function (url) {
   }
 };
 
-var getSuggest = function (url) {
+var getSuggest = function (url, keywordTags) {
   if (Pinboard.isLoggedin() && url) {
     var doneFn = function (data) {
       var popularTags = [], recommendedTags = [];
@@ -252,6 +252,15 @@ var getSuggest = function (url) {
           suggests.push(tag);
         }
       });
+
+      console.log("PRE Suggested Tags: " + keywordTags);
+
+	  if (keywordTags !== undefined && keywordTags.length !== 0) {
+        suggests = suggests.concat(keywordTags);
+        console.log("Post Suggested Tags: " + suggests);
+		suggests = suggests.sort().filter(function(item, pos, ary) {return !pos || item != ary[pos -  1];});
+      }
+
       var popup = getPopup();
       popup && popup.$rootScope &&
         popup.$rootScope.$broadcast('render-suggests', suggests);

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -253,8 +253,6 @@ var getSuggest = function (url, keywordTags) {
         }
       });
 
-      console.log("PRE Suggested Tags: " + keywordTags);
-
 	  if (keywordTags !== undefined && keywordTags.length !== 0) {
         suggests = suggests.concat(keywordTags);
         console.log("Post Suggested Tags: " + suggests);

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -253,14 +253,13 @@ var getSuggest = function (url, keywordTags) {
         }
       });
 
-	  if (keywordTags !== undefined && keywordTags.length !== 0) {
+      if (keywordTags !== undefined && keywordTags.length !== 0) {
         suggests = suggests.concat(keywordTags);
-		suggests = suggests.sort().filter(function(item, pos, ary) {return !pos || item != ary[pos -  1];});
+        suggests = suggests.sort().filter(function(item, pos, ary) {return !pos || item != ary[pos -  1];});
       }
 
       var popup = getPopup();
-      popup && popup.$rootScope &&
-        popup.$rootScope.$broadcast('render-suggests', suggests);
+      popup && popup.$rootScope && popup.$rootScope.$broadcast('render-suggests', suggests);
     };
     Pinboard.getSuggest(url, doneFn);
   }

--- a/app/scripts/keywords_suggestions.js
+++ b/app/scripts/keywords_suggestions.js
@@ -1,0 +1,14 @@
+chrome.runtime.onMessage.addListener(
+  function(message, sender, sendResponse) {
+    if (message.method == "getKeywordsSuggestionTags") {
+	  var metas = document.getElementsByTagName('meta');
+	    for (i=0; i < metas.length; i++) {  
+		  if (metas[i].getAttribute("name") === "keywords") {
+			var tags = metas[i].getAttribute("content").toLowerCase().replace(/,/g, ' ').replace(/;/, '').split(/(\s+)/).filter(function(e) { return e.trim().length > 0; }).sort().filter(function(item, pos, ary) {return !pos || item != ary[pos - 1];});
+			break
+            console.log("Tags: " + tags);
+		  }
+		}
+        sendResponse({data: tags});
+    }
+});

--- a/app/scripts/keywords_suggestions.js
+++ b/app/scripts/keywords_suggestions.js
@@ -2,12 +2,13 @@ chrome.runtime.onMessage.addListener(
   function(message, sender, sendResponse) {
     if (message.method == "getKeywordsSuggestionTags") {
 	  var metas = document.getElementsByTagName('meta');
-	    for (i=0; i < metas.length; i++) {  
-		  if (metas[i].getAttribute("name") === "keywords") {
-			var tags = metas[i].getAttribute("content").toLowerCase().replace(/,/g, ' ').replace(/;/, '').split(/(\s+)/).filter(function(e) { return e.trim().length > 0; }).sort().filter(function(item, pos, ary) {return !pos || item != ary[pos - 1];});
-			break
-		  }
+	  for (i=0; i < metas.length; i++) {  
+	    if (metas[i].getAttribute("name") === "keywords") {
+		  var tags = metas[i].getAttribute("content").toLowerCase().replace(/,/g, ' ').replace(/;/, '').split(/(\s+)/).filter(function(e) { return e.trim().length > 0; }).sort().filter(function(item, pos, ary) {return !pos || item != ary[pos - 1];});
+		  break
 		}
-        sendResponse({data: tags});
+      }
+      sendResponse({data: tags});
     }
-});
+  }
+);

--- a/app/scripts/keywords_suggestions.js
+++ b/app/scripts/keywords_suggestions.js
@@ -6,7 +6,6 @@ chrome.runtime.onMessage.addListener(
 		  if (metas[i].getAttribute("name") === "keywords") {
 			var tags = metas[i].getAttribute("content").toLowerCase().replace(/,/g, ' ').replace(/;/, '').split(/(\s+)/).filter(function(e) { return e.trim().length > 0; }).sort().filter(function(item, pos, ary) {return !pos || item != ary[pos - 1];});
 			break
-            console.log("Tags: " + tags);
 		  }
 		}
         sendResponse({data: tags});

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -74,6 +74,24 @@ app.controller(
          });
      };
 
+     var getKeywordsSuggestionTags = function () {
+       chrome.tabs.query(
+         {active:true, currentWindow: true}, function (activetabs) {
+           var tab = activetabs[0];
+           chrome.tabs.sendMessage(
+             tab.id, {method: 'getKeywordsSuggestionTags'},
+             function (response) {
+               if (typeof response !== 'undefined') {
+                 var tags = response.data;
+                 bg.getSuggest(tab.url, tags);
+               }
+               else {
+                 bg.getSuggest(tab.url);
+               }
+             });
+         });
+     };
+
      var initAutoComplete = function () {
        var tags = bg.getTags();
        if (tags && tags.length) {
@@ -105,7 +123,8 @@ app.controller(
          $scope.isLoading = false;
          $scope.isAnony = false;
          $scope.$apply();
-         bg.getSuggest(tab.url);
+         //bg.getSuggest(tab.url);
+         getKeywordsSuggestionTags();
          initAutoComplete();
          if (location.search != '?focusHack') {
            location.search = '?focusHack';


### PR DESCRIPTION
Feature Add: utilizing local meta keywords tags to suggest better and more relevant tags.
### PR includes:

1.) New content script: `keywords_suggestions.js` with a `getKeywordsSuggestionTags` listener
(utilized for pulling out "meta keywords" content from websites

2.) updated manifest.json to include new `content script` allowance for `keywords_suggestions.js`

3.) Update to `background.js` to include optional parameter to pass local meta keywords, adding them to suggests, and de-dupping with popular and recommended tags.

4.) Updated to `popups.js` to include new `getKeywordsSuggestionTags` tab message sender (to our `getKeywordsSuggestionTags` listener from the `keywords_suggestions.js`), which either overloads `getSuggests` (in the `background.js`) with the local meta keywords, or if none are present, passes along the Pinboard suggestions.

### Examples/Test with:
* nytimes.com
* washingtonpost.com
* any custom site which includes meta keywords:
```
<html>
<head>
<meta content="exampletag1 someothertag yetanothertag news daily rss" name="keywords">
<title>test.com</title>
</head>
<body>Test.com</body>
</html>
```