### PR TITLE
Fix tags autocompletion case sensitive issue #41

### DIFF
--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -198,10 +198,11 @@ app.controller(
          var allTags = $scope.allTags,
              shownCount = 0, autoCompleteItems = [];
          for (var i=0, len=allTags.length; i<len &&
-                           shownCount < MAX_SHOWN_ITEMS; i++) {
+                  shownCount < MAX_SHOWN_ITEMS; i++) {
+           // Filter with the lower cases, show the tag in original case
            var tag = allTags[i].toLowerCase();
            if (tag.indexOf(word) == 0) {
-             var item = {text:tag, isActive: false};
+             var item = {text:allTags[i], isActive: false};
              autoCompleteItems.push(item);
              shownCount += 1;
            }


### PR DESCRIPTION
Show the original case of the tag in the auto-completion list.

The reason of using the lower case is to filter the user's tags by the input, but actually no need to show and submit the lower case, let's use the original one to show and submit.