### PR TITLE
fix #55, sourcemaps should not be built as they're not part of the package

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -53,9 +53,7 @@ gulp.task('html',  () => {
              .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
              .pipe($.sourcemaps.init())
              .pipe($.if('*.js', $.uglify()))
-             .pipe($.if('*.js', $.sourcemaps.write('.')))
              .pipe($.if('*.css', $.cleanCss({compatibility: '*'})))
-             .pipe($.if('*.css', $.sourcemaps.write('.')))
              .pipe($.if('*.html', $.htmlmin({removeComments: true, collapseWhitespace: true})))
              .pipe(gulp.dest('dist'));
 });
@@ -72,9 +70,7 @@ gulp.task('chromeManifest', () => {
                }
              }))
              .pipe($.if('*.css', $.cleanCss({compatibility: '*'})))
-             .pipe($.if('*.js', $.sourcemaps.init()))
              .pipe($.if('*.js', $.uglify()))
-             .pipe($.if('*.js', $.sourcemaps.write('.')))
              .pipe(gulp.dest('dist'));
 });
 


### PR DESCRIPTION
Since the sourcemaps are not part of the distributed package, it's better to not make them part of the build. Fixes issue #55.